### PR TITLE
Update main.py: added wireless adb compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import tempfile
 import shutil
+import hashlib
 
 __app__ = "Tingle"
 __author__ = "ale5000, moosd"
@@ -574,7 +575,7 @@ print_(str(" *** Working dir: {0}").format(TMP_DIR))
 if mode == 1:
     print_(" *** Selected device:", SELECTED_DEVICE)
 
-OUTPUT_PATH = os.path.join(SCRIPT_DIR, "output", SELECTED_DEVICE)
+OUTPUT_PATH = os.path.join(SCRIPT_DIR, "output", hashlib.md5(SELECTED_DEVICE.encode('utf-8')).hexdigest())
 if not os.path.exists(OUTPUT_PATH):
     os.makedirs(OUTPUT_PATH)
 


### PR DESCRIPTION
Now you can patch your phone without USB cable!
changed output directory name to md5 hash of initial device name: now it works with wirelessly connected adb devices

example:
```
    >adb connect 192.168.0.5:5555
    >python main.py
        MENU
            1 - Patch file from a device (adb)
```
Voila!